### PR TITLE
Improve notebook documentation and organization

### DIFF
--- a/qraft_repro.ipynb
+++ b/qraft_repro.ipynb
@@ -5,7 +5,9 @@
    "id": "ff425892",
    "metadata": {},
    "source": [
-    "# Reproduction of QRAFT"
+    "# Reproduction of QRAFT\n",
+    "\n",
+    "This notebook reconstructs the QRAFT workflow for generating noisy quantum circuit data and training a machine learning model for error mitigation.\n"
    ]
   },
   {
@@ -13,7 +15,9 @@
    "id": "40a4710b",
    "metadata": {},
    "source": [
-    "## imports"
+    "## Imports and setup\n",
+    "\n",
+    "Load core Qiskit, scikit-learn, and helper libraries used throughout the notebook.\n"
    ]
   },
   {
@@ -67,11 +71,20 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Simulator configuration\n",
+    "Initialize ideal and noisy Aer simulators using a fake quantum device noise model.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8ba08191",
    "metadata": {},
    "source": [
-    "## Step 1:\n",
-    "Generate random forward circuits of varying circuit characteristic"
+    "## Step 1: Random circuit generation\n",
+    "\n",
+    "Create diverse random circuits that will be simulated to produce training samples.\n"
    ]
   },
   {
@@ -147,8 +160,8 @@
    "id": "9c1041bf",
    "metadata": {},
    "source": [
-    "## Step 1.1 \n",
-    "Generate the corresponding forward + reverse  circuits"
+    "### Forward and reverse circuits\n",
+    "Compose a forward circuit and its inverse to capture program and state errors.\n"
    ]
   },
   {
@@ -207,8 +220,9 @@
    "id": "b675f474",
    "metadata": {},
    "source": [
-    "## Step 2:\n",
-    "Execute the forward circuit and the forward + reverse circuit multiple times on a real quantum computer"
+    "## Step 2: Feature helpers\n",
+    "\n",
+    "Utility functions convert counts to probabilities, execute circuits, and derive per-state features.\n"
    ]
   },
   {
@@ -304,6 +318,7 @@
    "outputs": [],
    "source": [
     "def _pct(arr: List[float], q: float) -> float:\n",
+    "    \"\"\"Compute the q-th percentile of a list with compatibility across NumPy versions.\"\"\"\n",
     "    a = np.asarray(arr, dtype=float)\n",
     "    if a.size == 0:\n",
     "        return float(\"nan\")\n",
@@ -358,6 +373,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Dataset generation\n",
+    "\n",
+    "Run simulations and assemble features into a training dataset stored on disk.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "id": "3dc1dc76",
@@ -365,6 +389,7 @@
    "outputs": [],
    "source": [
     "def generate_samples(num_samples: int) -> List[Dict]:\n",
+    "    \"\"\"Simulate random circuits and collect statistics into a tabular dataset.\"\"\"\n",
     "    rng = random.Random()\n",
     "    rows: List[Dict] = []\n",
     "    backend = sim_noisy  # or sim_ideal\n",
@@ -635,7 +660,9 @@
    "id": "6c39fed1",
    "metadata": {},
    "source": [
-    "## Prediction Model"
+    "## Prediction Model\n",
+    "\n",
+    "Train an ensemble decision tree to predict ideal state probabilities from noisy observations.\n"
    ]
   },
   {
@@ -667,6 +694,7 @@
    "outputs": [],
    "source": [
     "def build_edt(\n",
+    "    \"\"\"Construct an ensemble decision tree regressor (bagging or AdaBoost).\"\"\"\n",
     "    ensemble=\"bag\",\n",
     "    n_estimators=200,\n",
     "    learning_rate=0.1,\n",
@@ -789,6 +817,14 @@
     "print(f\"Test MAE:  {mae:.6f}\")\n",
     "print(f\"Test RMSE: {rmse:.6f}\")\n",
     "print(f\"L1 sum abs diff: {l1_total:.6f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evaluate model predictions\n",
+    "Compare the trained model against the noisy baseline using standard error metrics.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add descriptive markdown sections for simulator setup, feature helpers, dataset generation, and evaluation
- document helper utilities with concise docstrings for clarity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c62c4f4e888321aacf8b81ea10bc48